### PR TITLE
Bump versions of actually supported versions of extras.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/demo/client/application/extras/BootstrapSelectView.ui.xml
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/extras/BootstrapSelectView.ui.xml
@@ -56,7 +56,7 @@
                     Bootstrap Select
                 </b:Anchor>
                 <b.html:Br/>
-                <b.html:Strong>Current Version Supported: 1.5.4</b.html:Strong>
+                <b.html:Strong>Current Version Supported: 1.6.3</b.html:Strong>
             </b:BlockQuote>
 
             <b:BlockQuote addStyleNames="{style.danger}">

--- a/src/main/java/org/gwtbootstrap3/demo/client/application/extras/ToggleSwitchView.ui.xml
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/extras/ToggleSwitchView.ui.xml
@@ -49,7 +49,7 @@
                     Switch
                 </b:Anchor>
                 <b.html:Br/>
-                <b.html:Strong>Current Version Supported: 3</b.html:Strong>
+                <b.html:Strong>Current Version Supported: 3.2.2</b.html:Strong>
             </b:BlockQuote>
 
             <b:BlockQuote addStyleNames="{style.danger}">


### PR DESCRIPTION
These versions changed between 0.8 and 0.9 and the demo was not updated to reflect this (in case of ToggleSwitch, it was my miss ;)).