### PR TITLE
FullCalendar support for select and unselect callbacks

### DIFF
--- a/src/main/java/org/gwtbootstrap3/demo/client/application/extras/FullCalendarView.java
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/extras/FullCalendarView.java
@@ -105,7 +105,8 @@ public class FullCalendarView extends ViewImpl implements FullCalendarPresenter.
                 Event calEvent = new Event(calendarEvent);
                 System.out.println("id " + calEvent.getId() + " start: " + calEvent.getStart() + " end: " + calEvent.getEnd() + " all day: "
                         + calEvent.isAllDay());
-                Window.alert(calEvent.getTitle());
+                if (Window.confirm("Delete '" + calEvent.getTitle() + "'?"))
+                    configuringCalendar.removeEvent(calEvent.getId());
             }
 
             @Override
@@ -116,6 +117,27 @@ public class FullCalendarView extends ViewImpl implements FullCalendarPresenter.
         });
 
         config.setClickHoverConfig(clickHover);
+        SelectConfig selectConfig = new SelectConfig(new SelectEventCallback() {
+
+            @Override
+            public void select(JavaScriptObject start, JavaScriptObject end, NativeEvent event, JavaScriptObject viewObject) {
+                Event tempEvent = new Event("" + System.currentTimeMillis(), "New event");
+                tempEvent.setStart(start);
+                tempEvent.setEnd(end);
+                if (tempEvent.getEnd().getHours() == tempEvent.getStart().getHours() && tempEvent.getEnd().getMinutes() == tempEvent.getStart().getMinutes())
+                    tempEvent.setAllDay(true);
+                if (Window.confirm("Create event?")) {
+                    configuringCalendar.unselect();
+                    configuringCalendar.addEvent(tempEvent);
+                }
+            }
+
+            @Override
+            public void unselect(JavaScriptObject viewObject, NativeEvent event) {
+                // System.out.println("unselect");
+            }
+        });
+        config.setSelectConfig(selectConfig);
         DragAndResizeConfig dr = new DragAndResizeConfig(new DragAndResizeCallback() {
 
             @Override

--- a/src/main/java/org/gwtbootstrap3/demo/client/application/extras/FullCalendarView.ui.xml
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/extras/FullCalendarView.ui.xml
@@ -139,6 +139,8 @@
 							public void eventClick(JavaScriptObject calendarEvent, NativeEvent event,JavaScriptObject viewObject) {\n
 								Event calEvent = new Event(calendarEvent);\n
 								System.out.println("id " + calEvent.getId() + " start: " + calEvent.getStart() + " end: " + calEvent.getEnd() + " all day: " + calEvent.isAllDay());\n
+								if (Window.confirm("Delete '" + calEvent.getTitle() + "'?"))
+                    				configuringCalendar.removeEvent(calEvent.getId());\n
 								Window.alert(calEvent.getTitle());\n
 							}\n
 
@@ -148,6 +150,27 @@
 						});\n
 
                         config.setClickHoverConfig(clickHover);\n
+                        SelectConfig selectConfig = new SelectConfig(new SelectEventCallback() {\n
+                        \n
+				            \s@Override\n
+				            \spublic void select(JavaScriptObject start, JavaScriptObject end, NativeEvent event, JavaScriptObject viewObject) {\n
+				                \s\sEvent tempEvent = new Event("" + System.currentTimeMillis(), "New event");\n
+				                \s\stempEvent.setStart(start);\n
+				                \s\stempEvent.setEnd(end);\n
+				                \s\sif (tempEvent.getEnd().getHours() == tempEvent.getStart().getHours() &amp;&amp; tempEvent.getEnd().getMinutes() == tempEvent.getStart().getMinutes())\n
+				                    \s\s\stempEvent.setAllDay(true);\n
+				                \s\sif (Window.confirm("Create event?")) {\n
+				                    \s\s\sconfiguringCalendar.unselect();\n
+				                    \s\sconfiguringCalendar.addEvent(tempEvent);\n
+				                \s\s}\n
+				            \s}\n
+							\n
+				            \s@Override\n
+				            \spublic void unselect(JavaScriptObject viewObject, NativeEvent event) {\n
+				            \s\s// System.out.println("unselect");\n
+				            \s}\n
+				        });\n
+				        config.setSelectConfig(selectConfig);\n
 						DragAndResizeConfig dr = new DragAndResizeConfig(new DragAndResizeCallback() {\n
 
                         @Override\n


### PR DESCRIPTION
I have extended the first calendar example with the proposed select callback feature. Clicking into an empty slot of the calendar will allow to create a new event (vs currently nothing happens) and clicking an existing event will allow to delete it (vs currently an alert box shows the event name).

Since the demo does not provide any other way of creating of deleting events I think it is kind of a nice example, obviously it also make it a bit more complicated. I do not have a strong view about changing the demo, put it in if you like it or else please ignore.