### PR TITLE
Fix for issue #99: Collapse nav bar upon navigation etc.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/demo/client/application/ApplicationPresenter.java
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/ApplicationPresenter.java
@@ -21,10 +21,7 @@ package org.gwtbootstrap3.demo.client.application;
  */
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Window;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
@@ -32,7 +29,10 @@ import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.View;
 import com.gwtplatform.mvp.client.annotations.ProxyStandard;
 import com.gwtplatform.mvp.client.presenter.slots.NestedSlot;
+import com.gwtplatform.mvp.client.proxy.NavigationEvent;
+import com.gwtplatform.mvp.client.proxy.NavigationHandler;
 import com.gwtplatform.mvp.client.proxy.Proxy;
+import org.gwtbootstrap3.client.ui.NavbarCollapse;
 
 /**
  * @author Joshua Godi
@@ -44,6 +44,7 @@ public class ApplicationPresenter extends Presenter<ApplicationPresenter.MyView,
     }
 
     public interface MyView extends View {
+        NavbarCollapse getNavbarCollapse();
     }
 
     /**
@@ -57,17 +58,28 @@ public class ApplicationPresenter extends Presenter<ApplicationPresenter.MyView,
                          final MyProxy proxy) {
         super(eventBus, view, proxy, RevealType.Root);
 
-        // Making the window scroll to top on every page change
-        History.addValueChangeHandler(new ValueChangeHandler<String>() {
+        // need to reset display because display is not reloaded every time (like conventional web site)
+        eventBus.addHandler(NavigationEvent.getType(), new NavigationHandler() {
             @Override
-            public void onValueChange(ValueChangeEvent<String> event) {
+            public void onNavigation(NavigationEvent navigationEvent) {
                 Scheduler.get().scheduleDeferred(new Command() {
                     @Override
                     public void execute() {
+                        // Making the window scroll to top on every page change
                         Window.scrollTo(0, 0);
+                        // and collapse any nav menus
+                        hideNavbarCollapse();
                     }
                 });
             }
         });
+    }
+
+    private void hideNavbarCollapse() {
+        NavbarCollapse navbarCollapse = getView().getNavbarCollapse();
+        String ariaExpanded = navbarCollapse.getElement().getAttribute("aria-expanded");
+        if (Boolean.parseBoolean(ariaExpanded)) {
+            navbarCollapse.toggle();
+        }
     }
 }

--- a/src/main/java/org/gwtbootstrap3/demo/client/application/ApplicationView.java
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/ApplicationView.java
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewImpl;
+import org.gwtbootstrap3.client.ui.NavbarCollapse;
 
 /**
  * @author Joshua Godi
@@ -35,6 +36,13 @@ public class ApplicationView extends ViewImpl implements ApplicationPresenter.My
 
     @UiField
     SimplePanel contentContainer;
+    @UiField
+    NavbarCollapse navbarCollapse;
+
+    @Override
+    public NavbarCollapse getNavbarCollapse() {
+        return navbarCollapse;
+    }
 
     interface Binder extends UiBinder<Widget, ApplicationView> {
     }

--- a/src/main/java/org/gwtbootstrap3/demo/client/application/ApplicationView.ui.xml
+++ b/src/main/java/org/gwtbootstrap3/demo/client/application/ApplicationView.ui.xml
@@ -42,7 +42,7 @@
                         </b:NavbarBrand>
                         <b:NavbarCollapseButton dataTarget="#navbar-collapse"/>
                     </b:NavbarHeader>
-                    <b:NavbarCollapse b:id="navbar-collapse">
+                    <b:NavbarCollapse b:id="navbar-collapse" ui:field="navbarCollapse">
                         <b:NavbarNav>
                             <b:AnchorListItem text="Setup" targetHistoryToken="{nameTokens.getSetup}"/>
                             <b:ListDropDown>


### PR DESCRIPTION
This fix changes from History value change monitoring to NavigationEvent monitoring.  It also collapses the menu (small screens) in addition to scrolling to the top of the page when the user navigates.